### PR TITLE
fix(markdown): render table rows as aligned terminal tables

### DIFF
--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -121,16 +121,31 @@ function parseTableSeparator(line: string): TableAlign[] | null {
   return aligns
 }
 
+/** Every escape this module's own `fg`/`bold`/`italic`/`strike`/`underline`/`hyperlink` helpers emit: SGR sequences and OSC 8 hyperlinks (BEL- or ST-terminated). */
+// eslint-disable-next-line no-control-regex -- matching the ANSI escapes this module's own styling helpers emit requires their literal control bytes.
+const ANSI_RE = /\x1b\][^\x07]*\x07|\x1b\][^\x1b]*\x1b\\|\x1b\[[0-9;]*m/g
+
 /**
- * Pad `styled` (already ANSI-wrapped) out to `width` using `raw`'s
- * unstyled length, since ANSI escapes have string length but no visual
- * width. Like the rest of this module, width is `string.length` (UTF-16
- * code units) rather than a display-width count, so a wide/astral cell
- * (CJK, emoji) can under-pad its column — a known limitation shared with
- * the fixed-width horizontal rule above.
+ * Visible length of an already-styled cell: ANSI escapes have string length
+ * but no on-screen width, so measuring `styled.length` directly would
+ * overcount by however many escape bytes the cell's markup produced.
+ * Stripping them first — rather than measuring the pre-styling raw source
+ * — also fixes the companion bug that source length would otherwise cause:
+ * `**bold**`'s raw text is 4 characters longer than what it renders as, so
+ * a column sized from raw source overcounts a bold cell's true width, and
+ * that same bold cell then looks "wide enough" and gets under-padded
+ * relative to its plain siblings. Like the rest of this module, "visible"
+ * means UTF-16 code units after stripping escapes, not a true display-width
+ * count, so a wide/astral cell (CJK, emoji) can still under-pad — a known
+ * limitation shared with the fixed-width horizontal rule below.
  */
-function padCell(raw: string, styled: string, width: number, align: TableAlign): string {
-  const gap = Math.max(0, width - raw.length)
+function visibleLength(styled: string): number {
+  return styled.replace(ANSI_RE, '').length
+}
+
+/** Pad an already-styled cell out to `width`, measuring by `visibleLength` rather than `styled.length`. */
+function padCell(styled: string, width: number, align: TableAlign): string {
+  const gap = Math.max(0, width - visibleLength(styled))
   if (align === 'right') return ' '.repeat(gap) + styled
   if (align === 'center') {
     const left = Math.floor(gap / 2)
@@ -139,14 +154,10 @@ function padCell(raw: string, styled: string, width: number, align: TableAlign):
   return styled + ' '.repeat(gap)
 }
 
-/** Style one table row (header or body) to a single padded, column-aligned line. */
-function formatTableRow(cells: readonly string[], widths: readonly number[], aligns: readonly TableAlign[], isHeader: boolean): string {
+/** Pad one row of already-styled cells (header or body) to a single column-aligned line. */
+function formatTableRow(styledCells: readonly string[], widths: readonly number[], aligns: readonly TableAlign[], isHeader: boolean): string {
   return widths
-    .map((width, i) => {
-      const raw = cells[i] ?? ''
-      const styled = applyInline(raw)
-      return padCell(raw, isHeader ? bold(styled) : styled, width, aligns[i] ?? 'left')
-    })
+    .map((width, i) => padCell(isHeader ? bold(styledCells[i] ?? '') : styledCells[i] ?? '', width, aligns[i] ?? 'left'))
     .join(dim(' │ '))
 }
 
@@ -176,19 +187,24 @@ export function renderMarkdown(text: string): string {
     if (!inCode && TABLE_ROW_RE.test(line) && i + 1 < lines.length) {
       const aligns = TABLE_ROW_RE.test(lines[i + 1]) ? parseTableSeparator(lines[i + 1]) : null
       if (aligns !== null) {
-        const header = splitTableRow(line)
-        const rows: string[][] = []
+        // Styled once here and reused for both width measurement and the
+        // final row text, so a column's width can never diverge from what
+        // padCell actually measures when placing its cells.
+        const styledHeader = splitTableRow(line).map(cell => applyInline(cell))
+        const styledRows: string[][] = []
         let j = i + 2
-        for (; j < lines.length && TABLE_ROW_RE.test(lines[j]); j++) rows.push(splitTableRow(lines[j]))
+        for (; j < lines.length && TABLE_ROW_RE.test(lines[j]); j++) {
+          styledRows.push(splitTableRow(lines[j]).map(cell => applyInline(cell)))
+        }
 
-        const columns = Math.max(header.length, ...rows.map(row => row.length), aligns.length)
+        const columns = Math.max(styledHeader.length, ...styledRows.map(row => row.length), aligns.length)
         const widths = Array.from({ length: columns }, (_, col) =>
-          Math.max(header[col]?.length ?? 0, ...rows.map(row => row[col]?.length ?? 0)))
+          Math.max(visibleLength(styledHeader[col] ?? ''), ...styledRows.map(row => visibleLength(row[col] ?? ''))))
         const columnAligns = Array.from({ length: columns }, (_, col) => aligns[col] ?? 'left')
 
-        out.push(formatTableRow(header, widths, columnAligns, true))
+        out.push(formatTableRow(styledHeader, widths, columnAligns, true))
         out.push(formatTableRule(widths))
-        for (const row of rows) out.push(formatTableRow(row, widths, columnAligns, false))
+        for (const styledRow of styledRows) out.push(formatTableRow(styledRow, widths, columnAligns, false))
 
         i = j - 1
         continue

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -4,7 +4,7 @@
  * module detects whether a text blob is (at least partly) Markdown before
  * paying the cost of styling it — plain prose keeps rendering exactly as it
  * always has, only text carrying real Markdown syntax gets headers, bold,
- * lists, code spans, etc. converted to ANSI.
+ * lists, code spans, tables, etc. converted to ANSI.
  * @module @tomowang/dsh-tui/markdown
  */
 
@@ -32,6 +32,7 @@ const BLOCKQUOTE_RE = /^(\s*)((?:>\s?)+)(.*)$/
 const UNORDERED_RE = /^(\s*)([-*+])\s+(.*)$/
 const ORDERED_RE = /^(\s*)(\d+)([.)])\s+(.*)$/
 const TABLE_ROW_RE = /^\s*\|.*\|\s*$/
+const TABLE_SEPARATOR_CELL_RE = /^:?-+:?$/
 const LINK_RE = /\[([^\]\n]+)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/
 const BOLD_RE = /\*\*([^*\n]+)\*\*|__([^_\n]+)__/
 const INLINE_CODE_RE = /`([^`\n]+)`/
@@ -94,11 +95,71 @@ function applyInline(text: string): string {
     .join('')
 }
 
+type TableAlign = 'left' | 'center' | 'right'
+
+/** Split a line already confirmed by `TABLE_ROW_RE` into trimmed cells, dropping the framing `|`. */
+function splitTableRow(line: string): string[] {
+  const inner = line.trim().replace(/^\|/, '').replace(/\|$/, '')
+  return inner.split('|').map(cell => cell.trim())
+}
+
+/**
+ * A GFM delimiter row: every cell is dashes with optional leading/trailing
+ * colons for alignment. Returns each column's alignment, or `null` when
+ * `line` isn't a valid delimiter row — the caller then treats the preceding
+ * line as ordinary text rather than a table header.
+ */
+function parseTableSeparator(line: string): TableAlign[] | null {
+  const cells = splitTableRow(line)
+  const aligns: TableAlign[] = []
+  for (const cell of cells) {
+    if (!TABLE_SEPARATOR_CELL_RE.test(cell)) return null
+    const left = cell.startsWith(':')
+    const right = cell.endsWith(':')
+    aligns.push(left && right ? 'center' : right ? 'right' : 'left')
+  }
+  return aligns
+}
+
+/**
+ * Pad `styled` (already ANSI-wrapped) out to `width` using `raw`'s
+ * unstyled length, since ANSI escapes have string length but no visual
+ * width. Like the rest of this module, width is `string.length` (UTF-16
+ * code units) rather than a display-width count, so a wide/astral cell
+ * (CJK, emoji) can under-pad its column — a known limitation shared with
+ * the fixed-width horizontal rule above.
+ */
+function padCell(raw: string, styled: string, width: number, align: TableAlign): string {
+  const gap = Math.max(0, width - raw.length)
+  if (align === 'right') return ' '.repeat(gap) + styled
+  if (align === 'center') {
+    const left = Math.floor(gap / 2)
+    return ' '.repeat(left) + styled + ' '.repeat(gap - left)
+  }
+  return styled + ' '.repeat(gap)
+}
+
+/** Style one table row (header or body) to a single padded, column-aligned line. */
+function formatTableRow(cells: readonly string[], widths: readonly number[], aligns: readonly TableAlign[], isHeader: boolean): string {
+  return widths
+    .map((width, i) => {
+      const raw = cells[i] ?? ''
+      const styled = applyInline(raw)
+      return padCell(raw, isHeader ? bold(styled) : styled, width, aligns[i] ?? 'left')
+    })
+    .join(dim(' │ '))
+}
+
+/** A dim horizontal rule under the header row, with a cross at each column boundary. */
+function formatTableRule(widths: readonly number[]): string {
+  return dim(widths.map(width => '─'.repeat(width)).join('─┼─'))
+}
+
 /**
  * Render Markdown source to ANSI-styled terminal text: headers, fenced/
- * inline code, block quotes, ordered/unordered lists, rules, links, bold,
- * strikethrough, and emphasis. Text that `looksLikeMarkdown` rejects passes
- * through byte-for-byte unchanged.
+ * inline code, block quotes, ordered/unordered lists, rules, tables, links,
+ * bold, strikethrough, and emphasis. Text that `looksLikeMarkdown` rejects
+ * passes through byte-for-byte unchanged.
  */
 export function renderMarkdown(text: string): string {
   if (!looksLikeMarkdown(text)) return text
@@ -108,7 +169,32 @@ export function renderMarkdown(text: string): string {
   let fenceChar = ''
   let fenceLen = 0
 
-  for (const line of text.split('\n')) {
+  const lines = text.split('\n')
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+
+    if (!inCode && TABLE_ROW_RE.test(line) && i + 1 < lines.length) {
+      const aligns = TABLE_ROW_RE.test(lines[i + 1]) ? parseTableSeparator(lines[i + 1]) : null
+      if (aligns !== null) {
+        const header = splitTableRow(line)
+        const rows: string[][] = []
+        let j = i + 2
+        for (; j < lines.length && TABLE_ROW_RE.test(lines[j]); j++) rows.push(splitTableRow(lines[j]))
+
+        const columns = Math.max(header.length, ...rows.map(row => row.length), aligns.length)
+        const widths = Array.from({ length: columns }, (_, col) =>
+          Math.max(header[col]?.length ?? 0, ...rows.map(row => row[col]?.length ?? 0)))
+        const columnAligns = Array.from({ length: columns }, (_, col) => aligns[col] ?? 'left')
+
+        out.push(formatTableRow(header, widths, columnAligns, true))
+        out.push(formatTableRule(widths))
+        for (const row of rows) out.push(formatTableRow(row, widths, columnAligns, false))
+
+        i = j - 1
+        continue
+      }
+    }
+
     const fence = FENCE_RE.exec(line)
     if (fence !== null && (!inCode || (fence[2][0] === fenceChar && fence[2].length >= fenceLen))) {
       if (inCode) {

--- a/test/markdown.test.ts
+++ b/test/markdown.test.ts
@@ -3,6 +3,10 @@ import { looksLikeMarkdown, renderMarkdown } from '../src/markdown.js'
 
 const ESC = '\x1b['
 
+/** Strip SGR and OSC 8 escapes so a table-alignment assertion can compare visual column positions. */
+// eslint-disable-next-line no-control-regex -- matching the ANSI escapes this module's own `fg`/`hyperlink` helpers emit requires their literal control bytes.
+const stripAnsi = (s: string): string => s.replaceAll(/\x1b\][^\x07]*\x07|\x1b\][^\x1b]*\x1b\\|\x1b\[[0-9;]*m/g, '')
+
 describe('looksLikeMarkdown', () => {
   it('rejects plain prose', () => {
     expect(looksLikeMarkdown('Hello there, how can I help?')).toBe(false)
@@ -147,6 +151,73 @@ describe('renderMarkdown', () => {
     expect(out).toContain('the docs')
     expect(out).toContain('https://example.com')
     expect(out).not.toContain('[the docs]')
+  })
+
+  it('renders a table with aligned columns and a header rule', () => {
+    const doc = ['| Feature | Description |', '|---|---|', '| Bash | Run shell commands |', '| FS | Read and write files |'].join('\n')
+    const out = renderMarkdown(doc)
+    const lines = out.split('\n')
+    expect(lines).toHaveLength(4)
+    expect(out).not.toContain('---')
+    expect(out).toContain('┼')
+    expect(out).toContain('│')
+    expect(out).toContain('Feature')
+    expect(out).toContain('Bash')
+    expect(out).toContain('Run shell commands')
+    // Same column start for every data row: the widest cell in each column
+    // sets that column's width for every other row. Strip ANSI first — the
+    // bold header carries extra escape bytes before its pipe that a raw
+    // string index would wrongly count against the visual column.
+    const barColumn = (line: string): number => stripAnsi(line).indexOf('│')
+    expect(barColumn(lines[0])).toBe(barColumn(lines[2]))
+    expect(barColumn(lines[0])).toBe(barColumn(lines[3]))
+  })
+
+  it('bolds the table header row', () => {
+    const out = renderMarkdown('| a |\n|---|\n| b |')
+    const lines = out.split('\n')
+    expect(lines[0]).toContain(`${ESC}1m`)
+    expect(lines[2]).not.toContain(`${ESC}1m`)
+  })
+
+  it('applies inline formatting inside table cells', () => {
+    const out = renderMarkdown('| Name | Note |\n|---|---|\n| `x` | **important** |')
+    expect(out).toContain('important')
+    expect(out).not.toContain('**')
+    expect(out).not.toContain('`x`')
+  })
+
+  it('right-aligns and center-aligns columns per the delimiter row', () => {
+    // Two data rows so each column has a narrower cell whose padding is
+    // actually observable (a column's widest cell gets none by definition).
+    const out = renderMarkdown('| L | C | R |\n|:--|:-:|--:|\n| a | bb | c |\n| aaa | b | ccc |')
+    const lines = stripAnsi(out).split('\n')
+    // R is right-aligned: the narrower 'c' (row 1) pads on the left to match 'ccc' (row 2).
+    expect(lines[2].endsWith('  c')).toBe(true)
+    // C is centered: the narrower 'b' (row 2) pads to match the 2-wide 'bb' column, trimming to 'b'.
+    const cCell = (line: string): string => line.split('│')[1]?.trim()
+    expect(cCell(lines[2])).toBe('bb')
+    expect(cCell(lines[3])).toBe('b')
+  })
+
+  it('does not treat an isolated pipe-containing line as a table', () => {
+    const out = renderMarkdown('this has a | pipe but no header/separator pair, and **bold**')
+    expect(out).not.toContain('┼')
+    expect(out).toContain('bold')
+  })
+
+  it('does not treat a table-like line inside a fenced code block as a table', () => {
+    const out = renderMarkdown('```\n| a | b |\n|---|---|\n```')
+    expect(out).not.toContain('┼')
+    expect(out).toContain('| a | b |')
+  })
+
+  it('handles ragged rows with fewer or more cells than the header', () => {
+    const out = renderMarkdown('| a | b | c |\n|---|---|---|\n| short |\n| long | row | with | extra |')
+    const lines = out.split('\n')
+    expect(lines).toHaveLength(4)
+    expect(out).toContain('short')
+    expect(out).toContain('extra')
   })
 
   it('handles a mixed document with headers, lists, and code together', () => {

--- a/test/markdown.test.ts
+++ b/test/markdown.test.ts
@@ -187,6 +187,17 @@ describe('renderMarkdown', () => {
     expect(out).not.toContain('`x`')
   })
 
+  it('sizes and pads a column from visible length, not raw Markdown source length', () => {
+    // A bold cell's raw source ('**abc**', 7 chars) is longer than what it
+    // renders as ('abc', 3 chars); sizing/padding from the raw source both
+    // inflates the column past its true widest visible cell (here 'Note',
+    // 4 chars) and leaves the bold cell itself under-padded, since its
+    // already-long raw length looks like it "fills" the inflated width.
+    const out = renderMarkdown('| Note |\n|---|\n| **abc** |\n| xyz |')
+    const lines = stripAnsi(out).split('\n')
+    expect(lines).toEqual(['Note', '────', 'abc ', 'xyz '])
+  })
+
   it('right-aligns and center-aligns columns per the delimiter row', () => {
     // Two data rows so each column has a narrower cell whose padding is
     // actually observable (a column's widest cell gets none by definition).


### PR DESCRIPTION
TABLE_ROW_RE was only used by looksLikeMarkdown() to decide a blob is worth styling at all; renderMarkdown() had no per-table branch, so a detected table row fell through to plain inline styling and printed its literal `|`/`---` syntax unchanged.

Buffer a header row + valid GFM delimiter row + following table rows into one block, compute each column's width from its widest cell, and render a bold header, a dim rule with column crosses, and left/center/ right-aligned body rows per the delimiter's alignment markers. Padding is computed from each cell's unstyled length so embedded ANSI escapes (bold, inline code, links) don't throw off column alignment.